### PR TITLE
fix: eslint parenthesis spacing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,7 @@ module.exports = {
     '@typescript-eslint/semi': ['error', 'always'],
 
     'space-before-function-paren': 'off',
-    '@typescript-eslint/space-before-function-paren': ['error', 'always'],
+    '@typescript-eslint/space-before-function-paren': ['error', 'never'],
 
     ///
     ///

--- a/examples/strong-typed/aws-handler-inline.ts
+++ b/examples/strong-typed/aws-handler-inline.ts
@@ -6,7 +6,7 @@ import { AmazonWebServiceApplication } from '../../src/provider/aws';
 declare const app: AmazonWebServiceApplication;
 
 const target = app.lambda('aws:apigw:proxy:v2')
-  .handle(async ({ context }) => {
+  .handle(async({ context }) => {
     context.request;
   });
 

--- a/examples/strong-typed/aws-middleware-complex.ts
+++ b/examples/strong-typed/aws-middleware-complex.ts
@@ -23,7 +23,7 @@ const target = app.lambda('aws:apigw:proxy:v2')
   .use(withFilters)
   .use(withPagination)
   .use(withFilterValidation)
-  .handle(async ({ context }) => {
+  .handle(async({ context }) => {
     context.request;
 
     context.pagination.page;

--- a/src/application/handler.spec.ts
+++ b/src/application/handler.spec.ts
@@ -11,7 +11,7 @@ type TestHandlerBuilder = HandlerBuilder<TestInbound, TestContext, TestWrapperIn
 /**
  * A test wrapper that appends its own string to the executors response.
  */
-const composingTextWrapper: TestWrapper = (executor) => async () => {
+const composingTextWrapper: TestWrapper = (executor) => async() => {
   const result = await executor({
     inbound: {
       test: true,
@@ -28,7 +28,7 @@ const composingTextWrapper: TestWrapper = (executor) => async () => {
 /**
  * A pass through wrapper that just gives the executions response.
  */
-const passThroughWrapper: TestWrapper = (executor) => async () => {
+const passThroughWrapper: TestWrapper = (executor) => async() => {
   return executor({
     inbound: {
       test: true,
@@ -43,13 +43,13 @@ const passThroughWrapper: TestWrapper = (executor) => async () => {
 describe('src/application/handler.ts', (): void => {
   describe('HandlerBuilder', (): void => {
     describe('custom wrapper implementation', (): void => {
-      it('given wrapper that ignores executor, returns fixed value', async (): Promise<void> => {
-        const wrapper: TestWrapper = () => async () => {
+      it('given wrapper that ignores executor, returns fixed value', async(): Promise<void> => {
+        const wrapper: TestWrapper = () => async() => {
           return 'assert:wrapper:response';
         };
 
         const builder = new HandlerBuilder('test:provider', wrapper);
-        const handler = builder.handle(async () => {
+        const handler = builder.handle(async() => {
           return 'ignored:handler:response';
         });
 
@@ -60,9 +60,9 @@ describe('src/application/handler.ts', (): void => {
     });
 
     describe('use cases', (): void => {
-      it('given no middleware, base context is given to handler', async () => {
+      it('given no middleware, base context is given to handler', async() => {
         const builder: TestHandlerBuilder = new HandlerBuilder('test:provider', composingTextWrapper);
-        const handler = builder.handle(async ({ context }) => {
+        const handler = builder.handle(async({ context }) => {
           return context.foo;
         });
 
@@ -71,9 +71,9 @@ describe('src/application/handler.ts', (): void => {
         expect(response).toBe('wrapper("baz")');
       });
 
-      it('given no middleware, response from handler is given as execution response', async () => {
+      it('given no middleware, response from handler is given as execution response', async() => {
         const builder: TestHandlerBuilder = new HandlerBuilder('test:provider', composingTextWrapper);
-        const handler = builder.handle(async () => {
+        const handler = builder.handle(async() => {
           return 'handler-response';
         });
 
@@ -82,15 +82,15 @@ describe('src/application/handler.ts', (): void => {
         expect(response).toBe('wrapper("handler-response")');
       });
 
-      it('given single middleware, middleware changes response from handler, new response given as execution response', async () => {
+      it('given single middleware, middleware changes response from handler, new response given as execution response', async() => {
         const builder: TestHandlerBuilder = new HandlerBuilder('test:provider', composingTextWrapper);
         const handler = builder
-          .use(async ({ context, next }) => {
+          .use(async({ context, next }) => {
             const previous = await next(context);
 
             return `middleware:${previous}`;
           })
-          .handle(async () => {
+          .handle(async() => {
             return 'handler-response';
           });
 
@@ -99,15 +99,15 @@ describe('src/application/handler.ts', (): void => {
         expect(response).toBe('wrapper("middleware:handler-response")');
       });
 
-      it('given single middleware, middleware changes given context, handler receives new context', async () => {
+      it('given single middleware, middleware changes given context, handler receives new context', async() => {
         const builder: TestHandlerBuilder = new HandlerBuilder('test:provider', passThroughWrapper);
         const handler = builder
-          .use(async ({ next } ) => {
+          .use(async({ next } ) => {
             return next({
               theme: 'dark',
             });
           })
-          .handle(async ({ context }) => {
+          .handle(async({ context }) => {
             return `handler-response:${context.theme}`;
           });
 
@@ -116,10 +116,10 @@ describe('src/application/handler.ts', (): void => {
         expect(response).toEqual('handler-response:dark');
       });
 
-      it('given multiple middleware, each can change response of previous, given as execution response', async () => {
+      it('given multiple middleware, each can change response of previous, given as execution response', async() => {
         const builder: TestHandlerBuilder = new HandlerBuilder('test:provider', passThroughWrapper);
         const handler = builder
-          .use(async ({ context, next } ) => {
+          .use(async({ context, next } ) => {
             const previous = await next(context);
 
             return {
@@ -129,7 +129,7 @@ describe('src/application/handler.ts', (): void => {
               }
             };
           })
-          .use(async ({ context, next} ) => {
+          .use(async({ context, next} ) => {
             const previous = await next(context);
 
             return {
@@ -137,7 +137,7 @@ describe('src/application/handler.ts', (): void => {
               body: JSON.stringify(previous.body),
             };
           })
-          .handle(async () => {
+          .handle(async() => {
             return {
               headers: {},
               body: {}
@@ -154,17 +154,17 @@ describe('src/application/handler.ts', (): void => {
         });
       });
 
-      it('given two middleware, altering contexts are merged for handler, handler recieves merged context', async () => {
+      it('given two middleware, altering contexts are merged for handler, handler recieves merged context', async() => {
         const builder: TestHandlerBuilder = new HandlerBuilder('test:provider', passThroughWrapper);
         const handler = builder
-          .use(async ({ next } ) => {
+          .use(async({ next } ) => {
             return next({
               headers: {
                 'content-type': 'text/html',
               }
             });
           })
-          .use(async ({ next} ) => {
+          .use(async({ next} ) => {
             return next({
               headers: {
                 'content-type': 'application/json',
@@ -172,7 +172,7 @@ describe('src/application/handler.ts', (): void => {
               }
             });
           })
-          .handle(async ({ context }) => {
+          .handle(async({ context }) => {
             return context;
           });
 
@@ -187,10 +187,10 @@ describe('src/application/handler.ts', (): void => {
         });
       });
 
-      it('given multiple middleware, altering contexts are deep merged, handler given deep merged context', async () => {
+      it('given multiple middleware, altering contexts are deep merged, handler given deep merged context', async() => {
         const builder: TestHandlerBuilder = new HandlerBuilder('test:provider', passThroughWrapper);
         const handler = builder
-          .use(async ({ next }) => {
+          .use(async({ next }) => {
             return next({
               some: {
                 nested: {
@@ -201,7 +201,7 @@ describe('src/application/handler.ts', (): void => {
               }
             });
           })
-          .use(async ({ next }) => {
+          .use(async({ next }) => {
             return next({
               some: {
                 nested: {
@@ -212,7 +212,7 @@ describe('src/application/handler.ts', (): void => {
               }
             });
           })
-          .use(async ({ next }) => {
+          .use(async({ next }) => {
             return next({
               some: {
                 nested: {
@@ -223,7 +223,7 @@ describe('src/application/handler.ts', (): void => {
               }
             });
           })
-          .handle(async ({ context }) => {
+          .handle(async({ context }) => {
             return context;
           });
 
@@ -243,25 +243,25 @@ describe('src/application/handler.ts', (): void => {
         });
       });
 
-      it('given several middleware, execution order is as expected', async () => {
+      it('given several middleware, execution order is as expected', async() => {
         const builder: TestHandlerBuilder = new HandlerBuilder('test:provider', composingTextWrapper);
         const handler = builder
-          .use(async ({ context, next }) => {
+          .use(async({ context, next }) => {
             const previous = await next(context);
 
             return `first:${previous}`;
           })
-          .use(async ({ context, next }) => {
+          .use(async({ context, next }) => {
             const previous = await next(context);
 
             return `second:${previous}`;
           })
-          .use(async ({ context, next }) => {
+          .use(async({ context, next }) => {
             const previous = await next(context);
 
             return `third:${previous}`;
           })
-          .handle(async () => {
+          .handle(async() => {
             return 'assert:response';
           });
 
@@ -271,15 +271,15 @@ describe('src/application/handler.ts', (): void => {
       });
 
       // @todo DELETE ONCE OTHERS ARE DONE
-      it('given simple middleware, middleware executed to modify response', async () => {
+      it('given simple middleware, middleware executed to modify response', async() => {
         const builder: TestHandlerBuilder = new HandlerBuilder('test:provider', composingTextWrapper);
         const handler = builder
-          .use(async ({ context, next }) => {
+          .use(async({ context, next }) => {
             const previous = await next(context);
 
             return `middleware:${previous}`;
           })
-          .handle(async () => {
+          .handle(async() => {
             return 'assert:response';
           });
 

--- a/src/application/handler.ts
+++ b/src/application/handler.ts
@@ -53,7 +53,7 @@ export class HandlerBuilder<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private readonly middlewares: Middleware<CurrentInbound, ContextConstraint, any>[] = [];
 
-  public constructor (
+  public constructor(
     public readonly provider: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private readonly wrapper: HandlerWrapper<any, any, any>,
@@ -81,11 +81,11 @@ export class HandlerBuilder<
     GivenHandler extends Handler<UnknownGivenContext>,
     UnknownGivenContext extends CurrentContext,
   >(handler: GivenHandler): ComposeFunction {
-    return this.wrapper(async ({ inbound, context }) => {
+    return this.wrapper(async({ inbound, context }) => {
       const wrapped = this.middlewares.reduceRight<MiddlewareNextFunction>(
         (previous, middleware) => {
-          return async (context) => {
-            const next: MiddlewareNextFunction = async (newcontext) => {
+          return async(context) => {
+            const next: MiddlewareNextFunction = async(newcontext) => {
               const merged = deepmerge(context, newcontext);
 
               return previous(merged);
@@ -94,7 +94,7 @@ export class HandlerBuilder<
             return middleware({ inbound, context, next });
           };
         },
-        async (context) => handler({ context }),
+        async(context) => handler({ context }),
       );
 
       return wrapped(context);

--- a/src/provider/aws.spec.ts
+++ b/src/provider/aws.spec.ts
@@ -12,9 +12,9 @@ describe('src/provider/aws.ts', (): void => {
   });
 
   describe('HandlerBuilder', (): void => {
-    it('no middleware', async () => {
+    it('no middleware', async() => {
       const handler = application.lambda('aws:apigw:proxy:v1')
-        .handle(async () => {
+        .handle(async() => {
           return 'assert:response';
         });
 
@@ -24,14 +24,14 @@ describe('src/provider/aws.ts', (): void => {
       expect(response).toBe('assert:response');
     });
 
-    it('composing middleware', async () => {
+    it('composing middleware', async() => {
       const handler = application.lambda('aws:apigw:proxy:v1')
-        .use(async ({ context, next }) => {
+        .use(async({ context, next }) => {
           const previous = await next(context);
 
           return `middleware:${previous}`;
         })
-        .handle(async () => {
+        .handle(async() => {
           return 'assert:response';
         });
 

--- a/src/provider/aws.ts
+++ b/src/provider/aws.ts
@@ -25,7 +25,7 @@ export type LambdaWrapper = HandlerWrapper<Lambda.InboundConstraint, Lambda.Cont
 /**
  * A typical implementation of the lambda wrapper.
  */
-export const wrapper: LambdaWrapper = (executor) => async (event, context) => {
+export const wrapper: LambdaWrapper = (executor) => async(event, context) => {
   return executor({
     inbound: {
       event,


### PR DESCRIPTION
Had the wrong option selected for parenthesis spacing which made the functions differ when types were used.